### PR TITLE
Legacy building code map redirect fixes (v1.0.2)

### DIFF
--- a/src/Controller/MapRedirectController.php
+++ b/src/Controller/MapRedirectController.php
@@ -13,16 +13,16 @@ class MapRedirectController extends ControllerBase {
   /**
    * Redirects the legacy building code to the correct map URL.
    *
-   * @param string $building
+   * @param string|null $building
    *   The building code.
    *
    * @return \Symfony\Component\HttpFoundation\RedirectResponse
    *   A redirect response.
    */
   protected function mapRedirect($building) {
-    $building = strtoupper($building);
+    $building = $building ? strtoupper($building) : '';
     $buildings = $this->config('ucb_campus_map.configuration')->get('buildings');
-    $options = [];
+    $options = ['absolute' => TRUE];
     if (isset($buildings[$building])) {
       $options['fragment'] = '!m/' . $buildings[$building]['marker'];
     }

--- a/ucb_campus_map.info.yml
+++ b/ucb_campus_map.info.yml
@@ -2,5 +2,5 @@ name: CU Boulder Campus Map
 description: Enables the CU Boulder Campus Map.
 core_version_requirement: ^10 || ^11
 type: module
-version: '1.0.1'
+version: '1.0.2'
 package: CU Boulder


### PR DESCRIPTION
This update contains two legacy building code map redirect fixes. Trying absolute=TRUE option on the URL to fix issue 1, adds additional null check to fix issue 2.

[bug] Resolves CuBoulder/ucb_campus_map#3